### PR TITLE
37742976 - Catch bad gifs

### DIFF
--- a/src/com/android/messaging/datamodel/media/GifImageResource.java
+++ b/src/com/android/messaging/datamodel/media/GifImageResource.java
@@ -23,6 +23,7 @@ import android.support.rastermill.FrameSequence;
 import android.support.rastermill.FrameSequenceDrawable;
 
 import com.android.messaging.util.Assert;
+import com.android.messaging.util.LogUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,7 +56,14 @@ public class GifImageResource extends ImageResource {
 
     @Override
     public Drawable getDrawable(Resources resources) {
-        return new FrameSequenceDrawable(mFrameSequence);
+        try {
+            return new FrameSequenceDrawable(mFrameSequence);
+        } catch (final Exception e) {
+            // Malicious gif images can make platform throw different kind of exceptions. Catch
+            // them all.
+            LogUtil.e(LogUtil.BUGLE_TAG, "Error getting drawable for GIF", e);
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
* A security researcher crafted a gif that would cause the Android
Bitmap code to throw an NPE. That would cause messaging to crash when
decoding the NPE. Catch the NPE.

Test: manually tested the "crash.gif" attached to the bug. Stepped
through the debugger to verify we're catching the NPE and logging
the attempt. Verified normal gifs still work.

Bug: 37742976

Change-Id: Iab814d5b0b514bed0cecddd9a76f1fc095f90892
(cherry picked from commit 3671fd94ae1aad5c51d0730066e7f0c7b4c893ce)
(cherry picked from commit e0f247e3994869567288f8057d9e3afec1dd2fe6)