### PR TITLE
Messaging: Fix crash of blocked participant list activity

### DIFF
--- a/src/com/android/messaging/ui/BlockedParticipantsActivity.java
+++ b/src/com/android/messaging/ui/BlockedParticipantsActivity.java
@@ -16,12 +16,10 @@
 
 package com.android.messaging.ui;
 
-import android.app.Fragment;
 import android.os.Bundle;
 import android.view.MenuItem;
 
 import com.android.messaging.R;
-import com.android.messaging.util.Assert;
 
 /**
  * Show a list of currently blocked participants.
@@ -34,11 +32,6 @@ public class BlockedParticipantsActivity extends BugleActionBarActivity {
         setContentView(R.layout.blocked_participants_activity);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-    }
-
-    @Override
-    public void onAttachFragment(final Fragment fragment) {
-        Assert.isTrue(fragment instanceof BlockedParticipantsFragment);
     }
 
     @Override


### PR DESCRIPTION
This activity was asserting that *only* the blocked participant list
fragment is attached to it, but the lifecycle libraries also inject a
fragment for their internal purposes.

Change-Id: Iafd798337a38fc83cf45174b20a8b6a76bf20546