### PR TITLE
Messaging: Fix generating id in android namespace

### DIFF
--- a/res/layout/apn_preference_layout.xml
+++ b/res/layout/apn_preference_layout.xml
@@ -38,7 +38,7 @@
         android:background="?android:attr/selectableItemBackground">
 
         <TextView
-            android:id="@+android:id/title"
+            android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:focusable="true"
@@ -46,7 +46,7 @@
             android:textAppearance="?android:attr/textAppearanceListItem" />
 
         <TextView
-            android:id="@+android:id/summary"
+            android:id="@+id/summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@android:id/title"

--- a/src/com/android/messaging/ui/appsettings/ApnPreference.java
+++ b/src/com/android/messaging/ui/appsettings/ApnPreference.java
@@ -94,7 +94,7 @@ public class ApnPreference extends Preference implements
 
     public void setApnRadioButtonContentDescription(final CompoundButton buttonView) {
         final View widget = (View) buttonView.getParent();
-        final TextView tv = (TextView) widget.findViewById(android.R.id.title);
+        final TextView tv = (TextView) widget.findViewById(R.id.title);
         final String apnTitle = tv.getText().toString();
         buttonView.setContentDescription(apnTitle);
     }


### PR DESCRIPTION
Fixes:
res/layout/apn_preference_layout.xml:40: warn:
generated id 'android:id/title' for external package 'android'.
res/layout/apn_preference_layout.xml:48: warn:
generated id 'android:id/summary' for external package 'android'.

Change-Id: Ia096fa2e072ba4391e3adad52d3f9c9abed0e976