### PR TITLE
Messaging: Require external legacy storage

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -61,6 +61,7 @@
         android:appCategory="social"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/BugleTheme"
         android:supportsRtl="true">
 


### PR DESCRIPTION
Since the recent API bump, when trying to attach images
from the built-in picker, all images are shown blank due
to an EACCES permission error.

Change-Id: I0a7c581300879a43f251b2e6279a1c9c11ca79eb