### PR TITLE
Messaging: Fix quick reply feature on non wearable devices

### DIFF
--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -22,6 +22,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -862,16 +863,18 @@ public class BugleNotifications {
                 new NotificationCompat.Action.Builder(R.drawable.ic_wear_reply,
                         context.getString(replyLabelRes), replyPendingIntent);
 
+        final RemoteInput.Builder remoteInputBuilder = new RemoteInput.Builder(Intent.EXTRA_TEXT);
+        remoteInputBuilder.setLabel(context.getString(R.string.notification_reply_prompt));
+        if (context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH)) {
+            final String[] choices = context.getResources().getStringArray(
+                    R.array.notification_reply_choices);
+            remoteInputBuilder.setChoices(choices);
+        }
+
+        actionBuilder.addRemoteInput(remoteInputBuilder.build());
         notifBuilder.addAction(actionBuilder.build());
 
         // Support the action on a wearable device as well
-        final String[] choices = context.getResources().getStringArray(
-                R.array.notification_reply_choices);
-        final RemoteInput remoteInput = new RemoteInput.Builder(Intent.EXTRA_TEXT).setLabel(
-                context.getString(R.string.notification_reply_prompt)).
-                setChoices(choices)
-                .build();
-        actionBuilder.addRemoteInput(remoteInput);
         wearableExtender.addAction(actionBuilder.build());
     }
 


### PR DESCRIPTION
 * RemoteInput was not added previously, resulting in this feature
   broken on non wearable devices after commit 1aea19a.
   To properly fix this, we only add choices to RemoteInput
   on wearable devices.

Change-Id: I92d31ec1d6165ae1be121d5c4527c01cba214152