### PR TITLE
Messaging: Fix quick reply choices on wearable devices

### DIFF
--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -22,7 +22,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -865,17 +864,18 @@ public class BugleNotifications {
 
         final RemoteInput.Builder remoteInputBuilder = new RemoteInput.Builder(Intent.EXTRA_TEXT);
         remoteInputBuilder.setLabel(context.getString(R.string.notification_reply_prompt));
-        if (context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH)) {
-            final String[] choices = context.getResources().getStringArray(
-                    R.array.notification_reply_choices);
-            remoteInputBuilder.setChoices(choices);
-        }
-
         actionBuilder.addRemoteInput(remoteInputBuilder.build());
         notifBuilder.addAction(actionBuilder.build());
 
         // Support the action on a wearable device as well
-        wearableExtender.addAction(actionBuilder.build());
+        final NotificationCompat.Action.Builder wearActionBuilder =
+                new NotificationCompat.Action.Builder(R.drawable.ic_wear_reply,
+                        context.getString(replyLabelRes), replyPendingIntent);
+        final String[] choices = context.getResources().getStringArray(
+                R.array.notification_reply_choices);
+        remoteInputBuilder.setChoices(choices);
+        wearActionBuilder.addRemoteInput(remoteInputBuilder.build());
+        wearableExtender.addAction(wearActionBuilder.build());
     }
 
     private static void addReadAction(final NotificationCompat.Builder notifBuilder,


### PR DESCRIPTION
 * Turns out I misunderstood the usage of this piece of code,
   let's hope this is the last fix. Note that we should create
   another NotificationCompat.Action.Builder to add a different
   action on wear devices.

Change-Id: I0598d8ac10f98d1a437557a171f961f2d470b1f4